### PR TITLE
Fix header issues

### DIFF
--- a/J2ObjC-Pod.podspec
+++ b/J2ObjC-Pod.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
 
   s.requires_arc = true
-  s.preserve_paths = 'dist'
+
 
   s.prepare_command = <<-CMD
     Scripts/download.sh
@@ -32,8 +32,7 @@ Pod::Spec.new do |s|
 
   s.default_subspec = 'lib/all'
 
-  s.source_files = 'dist/include/**/*.h'
-  # s.public_header_files = 'dist/include/**/*.h'
+  s.public_header_files = 'dist/include/**/*.h'
   s.header_mappings_dir = 'dist/include'
 
   s.subspec 'lib' do |lib|


### PR DESCRIPTION
Header files from J2ObjC kept colliding with system headers (e.g.  `#import <string.h>` colliding with `org/apache/xpath/operations/String.h`). 

By making them not available as part of the pod source (by removing `s.source_files = 'dist/include/**/*.h`) and only supplying the header path along with keeping the folder structure, the collisions don't happen anymore. 

Seems to work.